### PR TITLE
Type fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,74 @@
-# ez-tools
+# ezell-tools
 
 A collection of mostly functional tools I use within projects
 
 ### Why?
 
-I've enjoyed using technologies such as ReScript, jQuery, built-ins such as array methods.
+I've enjoyed using technologies such as ReScript, jQuery, built-ins such as array methods and promises.
 
-In short, I'm learning I'm a fan of functional programming.
+Promises are really neat because if part of the promise chain fails, the rest of the chain branches off and fails gracefully. I wanted that kind method chaining, where we don't need to null check the input of each parameter within a function chain/pipe.
 
-So, this toolbelt of mine is something I can bring around to other projects, without lugging about the totality of libraries.
+Sure, there are better implementations available but, this toolbelt of mine is something I can bring around to other projects, without lugging about the totality of full FP libraries.
 
 ### What's in it?
 
 ```js
-import Box from 'ez-tools'
+import { Box } from 'ez-tools'
 
 const divide = (y: number) => (x: number) => y === 0 ? null : x / y
 const divideByTwo = divide(2)
 const divideByZero = divide(0)
 
-const five = Box(20).flatMap(divideByTwo).flatMap(divideByTwo)
+const five = Box(20).map(divideByTwo).map(divideByTwo).value // 5
+
+const nothing = Box(20).flatMap(divideByTwo).flatMap(divideByZero).value // undefined
 ```
+
+### What's the difference between Map and FlatMap methods?
+
+`flatMap` will assume everything is an `Option` type, meaning its contents may be `null` or `undefined`
+When a `null` or `undefined` `value` is found, the method chain will branch off and return a `None` type.
+
+Nested `Some` types are unwrapped.
+
+`map` will not make this assumption, and methods will chain without performing any optional value check, always returning a `Some` type.
+
+In short, when it comes to working with plain functions, and its output can be trusted, `map` is good enough.
+
+If the output of the function could be `null` or `undefined`, `flatMap` is preferred when chaining methods.
+
+### Where would one want to use an Option type?
+
+Many places? Object / dictionary / array lookups can be unsafe. Virtually anywhere one may expect a mixed value of `null | undefined | value`
+
+```js
+import { Option } from 'ez-tools'
+
+const divide = (y) => (x) => Option(y === 0 ? null : x / y)
+const divideByFour = divide(4)
+
+const six = divideByFour(20).map((x) => x + 1).value // 6
+```
+
+```js
+import { Option } from 'ez-tools'
+
+const contacts = new Map([
+  ['John', 'jd@jd.com'],
+  ['Jane', 'jned@jned.com']
+])
+
+function safeGet(table) {
+  return (key) => Option(table.get(key))
+}
+
+const getValue = safeGet(contacts)
+
+getValue('Ezell')
+  .map((email) => email.split('@'))
+  .tap((chunks) => console.log(chunks)) // undefined
+```
+
+### Why not use optional chaining and nullish coalescing?
+
+The goal is to abstract away this decision making altogether. One simply works with their data through a pipeline, and the pipeline will branch accordingly if theres a nullish value detected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ezell-toolbelt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "My personal toolbelt",
   "main": "lib/index.js",
   "scripts": {

--- a/src/__test__/option.test.ts
+++ b/src/__test__/option.test.ts
@@ -1,5 +1,17 @@
 import { Option } from '../option'
 
+function toSet<T>(iterable: Iterable<T>): Set<T> {
+  return new Set(iterable)
+}
+
+function toArray<T>(iterable: Iterable<T>): T[] {
+  return Array.from(iterable)
+}
+
+function divideBy(y: number) {
+  return (x: number) => Option(y === 0 ? null : x / y)
+}
+
 describe('option type', () => {
   it('should return undefined', () => {
     const result = Option(null)
@@ -9,5 +21,23 @@ describe('option type', () => {
   it('should return a value', () => {
     const result = Option(1)
     expect(result.value).toBe(1)
+  })
+
+  it('unwraps a nested option value', () => {
+    const divideByFour = divideBy(4)
+    const five = Option(20).flatMap(divideByFour).value
+    expect(five).toBe(5)
+  })
+
+  it('can map an option type', () => {
+    const divideByFour = divideBy(4)
+    const six = divideByFour(20).map((x) => x! + 1).value
+    expect(six).toBe(6)
+  })
+
+  it('maintains type through the chain', () => {
+    const arr = Option([1, 2, 3, 3])
+    const result = arr.flatMap(toSet).flatMap(toArray).value
+    expect(result).toStrictEqual([1, 2, 3])
   })
 })

--- a/src/none.ts
+++ b/src/none.ts
@@ -1,8 +1,10 @@
 import type { None as TNone } from './types'
 export function None<T>(x: T): TNone<T> {
   return {
+    type: 'None',
     value: undefined,
     map: (_fn) => None(x),
+    // @ts-ignore
     flatMap: (_fn) => None(x),
     tap: (_fn) => None(x)
   }

--- a/src/some.ts
+++ b/src/some.ts
@@ -3,11 +3,25 @@ import { tap } from './tap'
 import { flatMap } from './flatmap'
 import type { Some as TSome } from './types'
 
+function unwrap<T>(x: NonNullable<T> | TSome<NonNullable<T>>): NonNullable<T> {
+  const isSome = (x as TSome<NonNullable<T>>)?.type === 'Some'
+  const value = (x as TSome<NonNullable<T>>)?.value
+  const hasValue = value !== undefined
+
+  if (!isSome) return x as NonNullable<T>
+  if (!hasValue) return x as NonNullable<T>
+
+  return hasValue ? value : unwrap(x)
+}
+
 export function Some<T>(x: NonNullable<T>): TSome<T> {
   return {
-    value: x,
+    type: 'Some',
     map: map(x),
     flatMap: flatMap(x),
-    tap: tap(x)
+    tap: tap(x),
+    get value() {
+      return unwrap(x)
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,13 @@
 export interface None<T> {
+  type: 'None'
   value: undefined
   map: (fn: Function) => None<T>
-  flatMap: (fn: Function) => None<T>
+  flatMap: <U>(fn: (x: T) => U) => Option<U>
   tap: (fn: Function) => None<T>
 }
 
 export interface Some<T> {
+  type: 'Some'
   value: T
   map: <U>(fn: (x: T) => NonNullable<U>) => Some<U>
   flatMap: <U>(fn: (x: NonNullable<T>) => U) => Option<U>


### PR DESCRIPTION
To fix `Option<unknown>` appearing in `Option.flatMap` chains.

```typescript
import { Option } from '../option'

function toSet<T>(iterable: Iterable<T>): Set<T> {
  return new Set(iterable)
}

function toArray<T>(iterable: Iterable<T>): T[] {
  return Array.from(iterable)
}

const arr = Option([1, 2, 3, 3])
const result = arr.flatMap(toSet).flatMap(toArray) // would be Option<unkown[]>
```